### PR TITLE
[Sprint 2] 월드 진입 시 건물들의 리스트를 받아와 건물 선택 모달창에 그려주는 로직 구현 #36

### DIFF
--- a/backend/src/database/entities/Url.ts
+++ b/backend/src/database/entities/Url.ts
@@ -1,0 +1,14 @@
+export interface IUrl {
+    id: number;
+    url: string;
+}
+
+export class Url implements IUrl {
+    public id: number;
+    public url: string;
+
+    constructor(id: number, url: string) {
+        this.id = id;
+        this.url = url;
+    }
+}

--- a/backend/src/database/service/building.service.ts
+++ b/backend/src/database/service/building.service.ts
@@ -1,6 +1,10 @@
-import { buildingListError, addBuildingError } from '@shared/constants';
+import {
+    buildingListError,
+    addBuildingError,
+    buildingUrlError,
+} from '@shared/constants';
 import { Receiver, STATUS_CODE } from '@shared/db.receiver';
-import { pool2 } from '../connection';
+import { pool1, pool2 } from '../connection';
 import { IBuilding } from '../entities/Building';
 
 export const getBuildingList = async (): Promise<Receiver> => {
@@ -44,6 +48,24 @@ export const addBuilding = async (data: IBuilding): Promise<Receiver> => {
     } catch (err) {
         result.status = STATUS_CODE.FAIL;
         result.err = addBuildingError;
+        return result;
+    }
+};
+
+export const getBuildingUrl = async (): Promise<Receiver> => {
+    const result: Receiver = {
+        status: STATUS_CODE.SUCCESS,
+    };
+
+    try {
+        const sql = `SELECT id, url FROM building`;
+        const [urls] = await pool1.query(sql);
+
+        result.buildingUrl = JSON.parse(JSON.stringify(urls));
+        return result;
+    } catch (err) {
+        result.status = STATUS_CODE.FAIL;
+        result.err = buildingUrlError;
         return result;
     }
 };

--- a/backend/src/graphql/resolver/buildingResolver.ts
+++ b/backend/src/graphql/resolver/buildingResolver.ts
@@ -1,32 +1,17 @@
+import { STATUS_CODE } from '@shared/db.receiver';
 import { IResolvers } from 'graphql-tools';
-
-const dummy: any[] = [
-    {
-        id: 1,
-        x: 3,
-        y: 3,
-        uid: 1,
-        description: '테스트1',
-        scope: 'private',
-        password: '1234',
-        url: 'http://localhost:3000/assets/home.png',
-    },
-    {
-        id: 2,
-        x: 10,
-        y: 10,
-        uid: 4,
-        description: '테스트2',
-        scope: 'public',
-        password: '',
-        url: 'http://localhost:3000/assets/home.png',
-    },
-];
+import { getBuildingUrl } from 'src/database/service/building.service';
 
 const buildingResolver: IResolvers = {
     Query: {
-        buildingList: () => {
-            return dummy;
+        async buildingUrl(): Promise<Array<object>> {
+            const result = await getBuildingUrl();
+            if (
+                result.status == STATUS_CODE.SUCCESS &&
+                result.buildingUrl !== undefined
+            )
+                return result.buildingUrl;
+            else throw new Error(result.err);
         },
     },
 };

--- a/backend/src/graphql/schema/building.ts
+++ b/backend/src/graphql/schema/building.ts
@@ -3,12 +3,6 @@ import { gql } from 'apollo-server-express';
 const buildingTypeDef = gql`
     type IBuilding {
         id: Int
-        x: Int
-        y: Int
-        uid: Int
-        description: String
-        scope: String
-        password: String
         url: String
     }
 `;

--- a/backend/src/graphql/schema/queries.ts
+++ b/backend/src/graphql/schema/queries.ts
@@ -3,7 +3,7 @@ import { gql } from 'apollo-server-express';
 const queryTypeDefs = gql`
     type Query {
         worldList: [IWorld!]!
-        buildingList: [IBuilding]!
+        buildingUrl: [IBuilding]!
     }
 `;
 

--- a/backend/src/shared/constants.ts
+++ b/backend/src/shared/constants.ts
@@ -6,3 +6,5 @@ export const userListError = 'Fail to get User List';
 
 export const buildingListError = 'Fail to get Building List';
 export const addBuildingError = 'Fail to insert Building';
+
+export const buildingUrlError = 'Fail to get Building Url List';

--- a/backend/src/shared/db.receiver.ts
+++ b/backend/src/shared/db.receiver.ts
@@ -2,6 +2,7 @@ import { IBuilding } from 'src/database/entities/Building';
 import { IObject } from 'src/database/entities/Object';
 import { IUser } from 'src/database/entities/User';
 import { IWorld } from 'src/database/entities/World';
+import { IUrl } from 'src/database/entities/Url';
 
 export enum STATUS_CODE {
     SUCCESS = 1,
@@ -12,6 +13,7 @@ export interface Receiver {
     status: STATUS_CODE;
     err?: string;
     objectArr?: Array<IObject>;
+    buildingUrl?: Array<IUrl>;
     buildingArr?: Array<IBuilding>;
     addedBuilding?: IBuilding;
     worldArr?: Array<IWorld>;

--- a/frontend/src/components/Building/index.tsx
+++ b/frontend/src/components/Building/index.tsx
@@ -45,10 +45,12 @@ const Building = (props: IProps) => {
         ctx = canvas.getContext('2d');
         checkingCtx = checkingCanvas.getContext('2d');
 
-        buildingList.forEach((building) => {
-            fillBuildingPosition(building);
-            drawOriginBuildings(building);
-        });
+        if (buildingList[0].id !== -1) {
+            buildingList.forEach((building) => {
+                fillBuildingPosition(building);
+                drawOriginBuildings(building);
+            });
+        }
 
         if (socketClient === undefined) return;
         socketClient.on('buildBuilding', (data: IBuilding) => {
@@ -181,7 +183,6 @@ const Building = (props: IProps) => {
 
     const drawOriginBuildings = (building: IBuilding) => {
         if (!ctx) return;
-
         const buildingObject = new Image();
         buildingObject.src = building.imageUrl;
         buildingObject.onload = () => {

--- a/frontend/src/components/Building/index.tsx
+++ b/frontend/src/components/Building/index.tsx
@@ -45,7 +45,7 @@ const Building = (props: IProps) => {
         ctx = canvas.getContext('2d');
         checkingCtx = checkingCanvas.getContext('2d');
 
-        if (buildingList[0].id !== -1) {
+        if (buildingList.length !== 0 && buildingList[0].id !== -1) {
             buildingList.forEach((building) => {
                 fillBuildingPosition(building);
                 drawOriginBuildings(building);

--- a/frontend/src/components/Modal/BuildBuilding/index.tsx
+++ b/frontend/src/components/Modal/BuildBuilding/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { useSetRecoilState } from 'recoil';
+import { useSetRecoilState, useRecoilValue } from 'recoil';
 
 import styled from 'styled-components';
 import buildBuildingState from '../../../store/buildBuildingState';
+import buildingUrls from '../../../store/buildingUrlState';
 
 interface customEventTarget extends EventTarget {
     src: string;
@@ -14,6 +15,7 @@ interface customMouseEvent extends React.MouseEvent<HTMLButtonElement, MouseEven
 
 const BuildBuilding = () => {
     const setBuildBuilding = useSetRecoilState(buildBuildingState);
+    const buildingUrl = useRecoilValue(buildingUrls);
 
     const selectBuilding = (e: customMouseEvent) => {
         const selectedBuildingInfo = {
@@ -27,10 +29,34 @@ const BuildBuilding = () => {
     };
 
     return (
-        <button type="button" onMouseDown={selectBuilding}>
-            <img src="/assets/home.png" alt="빌드 가능한 빌딩 이미지" />
-        </button>
+        <ImgContainer>
+            {buildingUrl.map((url) => {
+                return (
+                    <ImgBtn key={url.url} type="button" onMouseDown={selectBuilding}>
+                        <InnerImg src={url.url} alt="빌드 가능한 빌딩 이미지" />
+                    </ImgBtn>
+                );
+            })}
+        </ImgContainer>
     );
 };
 
 export default BuildBuilding;
+
+const ImgContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-around;
+`;
+
+const ImgBtn = styled.button`
+    margin: 10px;
+    background-color: #c4c4c4;
+    border: 0;
+`;
+
+const InnerImg = styled.img`
+    width: 150px;
+    height: 150px;
+`;

--- a/frontend/src/components/Modal/index.tsx
+++ b/frontend/src/components/Modal/index.tsx
@@ -9,7 +9,6 @@ import currentModalState from '../../store/currentModalState';
 
 const Modal = () => {
     const [currentModal, setCurrentModal] = useRecoilState(currentModalState);
-
     return (
         <ModalDiv>
             <BackBtn src="/assets/nextbtn.png" onClick={() => setCurrentModal('none')} />
@@ -30,6 +29,9 @@ const ModalDiv = styled.div`
     right: 0;
     top: 0px;
     border: 3px solid black;
+
+    display: flex;
+    flex-direction: column;
 `;
 
 const BackBtn = styled.img`

--- a/frontend/src/pages/World/index.tsx
+++ b/frontend/src/pages/World/index.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { RouteComponentProps } from 'react-router';
+import { useQuery } from '@apollo/client';
 
 import currentWorldState from '../../store/currentWorldState';
 import currentModalState from '../../store/currentModalState';
 import buildBuildingState from '../../store/buildBuildingState';
+import buildingUrls from '../../store/buildingUrlState';
 
 import WorldBackground from '../../components/WorldMap';
 import Building from '../../components/Building';
@@ -17,6 +19,7 @@ import worldWinter from '../../map-files/world-winter.json';
 
 import { socketClient, setSocket } from '../../socket/socket';
 import { IWorldInfo } from '../../utils/model';
+import { getBuildingUrl } from '../../utils/query';
 
 interface customWorldInfo {
     [world: string]: typeof worldPark;
@@ -30,7 +33,7 @@ const World = (props: RouteComponentProps) => {
     const [worldInfo, setWorldInfo] = useState({
         buildings: [
             {
-                id: 1,
+                id: -1,
                 x: 3,
                 y: 3,
                 uid: 1,
@@ -42,8 +45,11 @@ const World = (props: RouteComponentProps) => {
         ],
     });
     const [currentWorld, setCurrentWorld] = useRecoilState(currentWorldState);
+    const [buildingUrl, setBuildingUrl] = useRecoilState(buildingUrls);
     const currentModal = useRecoilValue(currentModalState);
     const buildBuilding = useRecoilValue(buildBuildingState);
+
+    const { loading, error, data } = useQuery(getBuildingUrl);
 
     if (currentWorld.name === 'default') {
         props.history.push('/selectworld');
@@ -76,6 +82,13 @@ const World = (props: RouteComponentProps) => {
             socketClient.disconnect();
         };
     }, []);
+
+    useEffect(() => {
+        if (data) setBuildingUrl(data.buildingUrl);
+    }, [data]);
+
+    if (loading) return <p>Loading...</p>;
+    if (error) return <p>Error :(</p>;
 
     return (
         <>

--- a/frontend/src/store/buildingUrlState.tsx
+++ b/frontend/src/store/buildingUrlState.tsx
@@ -1,0 +1,13 @@
+import { atom } from 'recoil';
+
+const buildingUrlState = atom({
+    key: 'buildingUrlState',
+    default: [
+        {
+            id: 0,
+            url: '',
+        },
+    ],
+});
+
+export default buildingUrlState;

--- a/frontend/src/utils/hooks/useSlide.ts
+++ b/frontend/src/utils/hooks/useSlide.ts
@@ -10,17 +10,19 @@ export const useSlide = <T>(
     );
 
     const nextClick = () => {
-        if (index >= data.length - 1) setIndex(0);
-        else setIndex(index + 1);
-        setCurrent(data[index]);
-        setter(data[index]);
+        let nextIndex = index + 1;
+        if (nextIndex >= data.length) nextIndex = 0;
+        setIndex(nextIndex);
+        setCurrent(data[nextIndex]);
+        setter(data[nextIndex]);
     };
 
     const prevClick = () => {
-        if (index <= 0) setIndex(data.length - 1);
-        else setIndex(index - 1);
-        setCurrent(data[index]);
-        setter(data[index]);
+        let nextIndex = index - 1;
+        if (nextIndex < 0) nextIndex = data.length - 1;
+        setIndex(nextIndex);
+        setCurrent(data[nextIndex]);
+        setter(data[nextIndex]);
     };
 
     return [current, nextClick, prevClick];

--- a/frontend/src/utils/query.ts
+++ b/frontend/src/utils/query.ts
@@ -12,11 +12,10 @@ export const getWorldList = gql`
     }
 `;
 
-export const getBuildingList = gql`
+export const getBuildingUrl = gql`
     query Query {
-        buildingList {
-            x
-            y
+        buildingUrl {
+            id
             url
         }
     }


### PR DESCRIPTION
## PR 구현 내용
- 월드 진입 시 건물들의 리스트 요청
  - 백엔드 : graphql 스키마 작성 및 인터페이스 구현, 데이터베이스 서비스 로직 구현
  - 프론트엔드 : graphql 쿼리문 작성 및 받아온 리스트를 모달창에 display
- 약간의 리팩토링 및 임시값 그려지던 버그 해결

## 남아있는 문제
- 데이터 값을 확인하기 위한 콘솔 출력 제거해야함
- 건물 url들 임시로 넣은 값들이라 디자인적으로 안어울림

## 체크리스트
- [ ]  `console.log` 지우고 올리기
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [ ]  주석 밴
