### PR TITLE
[Sprint 3] 건물 관련 렌더링 및 빌드 로직 이슈 해결

### DIFF
--- a/frontend/src/components/Character/index.tsx
+++ b/frontend/src/components/Character/index.tsx
@@ -176,7 +176,7 @@ export const Character = () => {
 const Canvas = styled.canvas`
     bottom: 0;
     left: 0;
-    z-index: 100;
+    z-index: 2;
     position: absolute;
     display: flex;
     right: 0;


### PR DESCRIPTION
## PR 구현 내용
* 기존의 초기 월드페이지  진입 시 건물들이 그려지지 않는 이슈를 해결했습니다.
* 캐릭터 이동 후 건물 빌드 시 건물들의 좌표가 이상하게 렌더링되는 이슈를 해결했습니다.

## 남아있는 문제
* 캐릭터 이동 후 맵 상에서 건물 지을 수 있는 영역에 대한 테스트 및 추가적인 핸들링이 필요합니다.

## 체크리스트
- [x]  `console.log` 지우고 올리기
- [x]  .env파일, node_modules 올리지 않기
- [x]  IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [x]  주석 밴