### PR TITLE
[Sprint 5] 네비게이션 바 수정, 나가는 로직 구현, 카메라 로직 수정, 건물 짓는 로직 수정

### DIFF
--- a/frontend/src/components/Background/index.tsx
+++ b/frontend/src/components/Background/index.tsx
@@ -13,6 +13,7 @@ import { IBuildingInfo, UserMap } from '../../utils/model';
 import { Character } from '../Character';
 import Video from '../Video';
 import allUserListState from '../../store/allUserListState';
+import currentModalState from '../../store/currentModalState';
 
 interface ILayer {
     data: number[];
@@ -39,6 +40,7 @@ const WorldBackground = (props: IProps) => {
     const [tileBackground, setTileBackground] = useState<HTMLImageElement[]>();
     const user = useRecoilValue(userState);
     const [allUser, setAllUser] = useRecoilState(allUserListState);
+    const [currentModal, setCurrentModal] = useRecoilState(currentModalState);
     const commonWidth = layers[0].width;
     const tileSize = 32;
 
@@ -87,6 +89,7 @@ const WorldBackground = (props: IProps) => {
 
         socketClient.on('enter', (data: IBuildingInfo) => {
             setBuildingInfo(data);
+            setCurrentModal('none');
         });
         socketClient.on('allUserList', (data: UserMap) => {
             setAllUser(data);

--- a/frontend/src/components/Building/index.tsx
+++ b/frontend/src/components/Building/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 /* eslint-disable consistent-return */
 /* eslint-disable no-plusplus */
 /* eslint-disable react/destructuring-assignment */
@@ -123,6 +124,19 @@ const Building = (props: IProps) => {
 
     useEffect(() => {
         drawObjCanvas();
+        if (buildBuilding.isData || buildObject.isData) {
+            checkingCtx?.clearRect(0, 0, window.innerWidth, window.innerHeight);
+            const DefaultVal = {
+                src: 'none',
+                id: NONE,
+                roomId: NONE,
+                locationX: NONE,
+                locationY: NONE,
+                isLocated: false,
+                isData: false,
+            };
+            buildBuilding.isData ? setBuildBuilding(DefaultVal) : setBuildObject(DefaultVal);
+        }
     }, [user]);
 
     useEffect(() => {
@@ -252,7 +266,14 @@ const Building = (props: IProps) => {
         drawPossibleBox();
     };
 
-    const drawFunction = (ctx: any, img: any, sx: any, sy: any, dx: any, dy: any) => {
+    const drawFunction = (
+        ctx: CanvasRenderingContext2D | null,
+        img: HTMLCanvasElement | HTMLImageElement,
+        sx: number,
+        sy: number,
+        dx: number,
+        dy: number,
+    ) => {
         if (!ctx) return;
         ctx.drawImage(img, sx, sy, dx, dy);
     };

--- a/frontend/src/components/NavigationBar/Exit/index.tsx
+++ b/frontend/src/components/NavigationBar/Exit/index.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
 import styled from 'styled-components';
+import { Clickable } from '../../../utils/css';
 
-const Exit = () => {
+const Exit = ({ props }: { props: RouteComponentProps }) => {
+    const redirectSelectWorld = (event: React.MouseEvent) => {
+        event.preventDefault();
+        props.history.push('/selectWorld');
+    };
+
     return (
         <Icons
             src="/assets/logout.png"
-            onClick={() => {
-                console.log('나가기');
+            onClick={(e) => {
+                redirectSelectWorld(e);
             }}
         />
     );
@@ -17,4 +24,5 @@ export default Exit;
 const Icons = styled.img`
     width: 40px;
     height: 40px;
+    ${Clickable}
 `;

--- a/frontend/src/components/NavigationBar/Menu/index.tsx
+++ b/frontend/src/components/NavigationBar/Menu/index.tsx
@@ -22,6 +22,9 @@ const Menu = ({ props }: { props: RouteComponentProps }) => {
     };
 
     const menuList = icons.map((icon) => {
+        if (user.isInBuilding !== -1 && icon === 'buildBuilding') {
+            return null;
+        }
         return (
             <Icons
                 key={icon}

--- a/frontend/src/components/NavigationBar/index.tsx
+++ b/frontend/src/components/NavigationBar/index.tsx
@@ -12,7 +12,7 @@ const NavigationBar = ({ props }: { props: RouteComponentProps }) => {
     return (
         <FixedDiv>
             <SideDiv>
-                <Exit />
+                <Exit props={props} />
                 <UserLog />
             </SideDiv>
             <img src="/assets/navLogo.png" width="90px" height="80px" />

--- a/frontend/src/components/Video/index.tsx
+++ b/frontend/src/components/Video/index.tsx
@@ -186,6 +186,9 @@ const Video = () => {
                 pcsRef.current[user.id].close();
                 delete pcsRef.current[user.id];
             });
+            myStream.getTracks().forEach((track: MediaStreamTrack) => {
+                track.stop();
+            });
         };
     }, [socketClient, createPeerConnection, getMedia]);
 

--- a/worker-server/src/socket/socket.ts
+++ b/worker-server/src/socket/socket.ts
@@ -65,7 +65,6 @@ export default class RoomSocket {
             });
             socket.on('checkCapacity', (data: string) => {
                 const usersInRoom = rooms.get(data);
-                console.log(usersInRoom);
                 const isFull =
                     usersInRoom === undefined ||
                     usersInRoom.length < ROOM_CAPACITY
@@ -227,7 +226,6 @@ export default class RoomSocket {
             .get(roomId)
             .filter((user: string) => socket.id !== user);
         rooms.set(roomId, users);
-        console.log(roomId, socket.id);
         this.io.sockets.to(roomId).emit('userExit', socket.id);
     }
 }


### PR DESCRIPTION
## PR 내용
- 건물 내부에 들어갔을 때 네비게이션 바 건물 짓는 버튼 없앰
- 나가는 버튼 클릭 시 월드 선택 페이지로 이동
- 건물 밖으로 나가면 카메라 꺼지도록 수정
- 건물 지을 수 있는 영역에 대한 에러 처리

## 체크리스트
- [ ] console.log 지우고 올리기
- [x] .env파일, node_modules 올리지 않기
- [x] IP, PORT, SECRET KEY 등 → .env파일에 넣기
- [ ] 주석 밴