### PR TITLE
[Sprint 5] 로그인 후 월드 선택 페이지 진입 시 발생한 이슈 해결

### DIFF
--- a/frontend/src/pages/SelectWorld/index.tsx
+++ b/frontend/src/pages/SelectWorld/index.tsx
@@ -23,6 +23,7 @@ const SelectWorld = (props: RouteComponentProps) => {
         if (code) {
             const Login = async (code: string) => {
                 const userInfo = (await fetchUser({ variables: { code } })).data.user;
+                userInfo.isInBuilding = -1;
                 setUser(userInfo);
             };
             Login(code);


### PR DESCRIPTION
## PR 내용
기존의 로그인 후 월드 선택 페이지 진입 시 현재 사용자가 월드인지, 빌딩에 있는지에 대한 설정값이 없어서 빌딩 내부가 잠시 렌더링 되는 이슈해결