### PR TITLE
[Sprint 5] World 페이지의 하위 컴포넌트들 React.memo 적용

### DIFF
--- a/frontend/src/components/Character/index.tsx
+++ b/frontend/src/components/Character/index.tsx
@@ -22,7 +22,7 @@ import {
 const commonWidth = 70;
 const commonHeight = 50;
 
-export const Character = () => {
+export const Character = React.memo(() => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const [user, setUser] = useRecoilState(userState);
     const [characters, setCharacters] = useState<UserMap>({});
@@ -300,7 +300,7 @@ export const Character = () => {
             ref={canvasRef}
         />
     );
-};
+});
 
 const Canvas = styled.canvas`
     bottom: 0;

--- a/frontend/src/components/Modal/index.tsx
+++ b/frontend/src/components/Modal/index.tsx
@@ -12,7 +12,7 @@ import currentModalState from '../../store/currentModalState';
 import { Clickable } from '../../utils/css';
 import { ActiveModal } from '../../utils/model';
 
-const Modal = () => {
+const Modal = React.memo(() => {
     const [currentModal, setCurrentModal] = useRecoilState(currentModalState);
 
     return (
@@ -24,7 +24,7 @@ const Modal = () => {
             <AllUser active={currentModal === 'users'} />
         </ModalDiv>
     );
-};
+});
 
 export default Modal;
 

--- a/frontend/src/components/NavigationBar/index.tsx
+++ b/frontend/src/components/NavigationBar/index.tsx
@@ -8,7 +8,7 @@ import Exit from './Exit';
 import UserLog from './UserLog';
 import Menu from './Menu';
 
-const NavigationBar = ({ props }: { props: RouteComponentProps }) => {
+const NavigationBar = React.memo(({ props }: { props: RouteComponentProps }) => {
     return (
         <FixedDiv>
             <SideDiv>
@@ -21,7 +21,7 @@ const NavigationBar = ({ props }: { props: RouteComponentProps }) => {
             </SideDiv>
         </FixedDiv>
     );
-};
+});
 
 export default NavigationBar;
 

--- a/frontend/src/components/SetBuildingModal/index.tsx
+++ b/frontend/src/components/SetBuildingModal/index.tsx
@@ -11,6 +11,7 @@ import { socketClient } from '../../socket/socket';
 import buildBuildingState from '../../store/buildBuildingState';
 import userState from '../../store/userState';
 import { NONE } from '../../utils/constants';
+import { ActiveModal } from '../../utils/model';
 
 interface customEventTarget extends EventTarget {
     value: string;
@@ -24,7 +25,7 @@ interface customSetFunctions {
     [FunctionType: string]: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const setBuildingModal = () => {
+const setBuildingModal = React.memo(() => {
     const [description, setDescription] = useState('');
     const [range, setRange] = useState('private');
     const [password, setPassword] = useState('');
@@ -87,7 +88,7 @@ const setBuildingModal = () => {
     };
 
     return (
-        <ModalDiv>
+        <ModalDiv active={buildBuilding.isLocated}>
             <ElementDiv>
                 <TitleTag>설명</TitleTag>
                 <InputDescription id="description" onChange={changed} />
@@ -133,11 +134,11 @@ const setBuildingModal = () => {
             </BtnWrapper>
         </ModalDiv>
     );
-};
+});
 
 export default setBuildingModal;
 
-const ModalDiv = styled.div`
+const ModalDiv = styled.div<ActiveModal>`
     position: absolute;
     z-index: 3;
 
@@ -148,7 +149,7 @@ const ModalDiv = styled.div`
     background: #c4c4c4;
     margin: -240px 0 0 -200px;
 
-    display: flex;
+    display: ${(props) => (props.active === true ? 'none' : 'flex')};
     flex-direction: column;
     justify-content: space-around;
     align-items: center;

--- a/frontend/src/components/SetObjectModal/index.tsx
+++ b/frontend/src/components/SetObjectModal/index.tsx
@@ -15,10 +15,10 @@ import userState from '../../store/userState';
 
 import { DEFAULT_INDEX, NONE } from '../../utils/constants';
 
-import { IUser, IWorld } from '../../utils/model';
+import { ActiveModal, IUser, IWorld } from '../../utils/model';
 import { getUploadUrl } from '../../utils/query';
 
-const setBuildingModal = () => {
+const setBuildingModal = React.memo(() => {
     const worldInfo = useRecoilValue<IWorld>(currentWorldState);
     const userInfo = useRecoilValue<IUser>(userState);
     const [buildObject, setBuildObject] = useRecoilState(buildObjectState);
@@ -83,7 +83,7 @@ const setBuildingModal = () => {
     };
 
     return (
-        <ModalDiv>
+        <ModalDiv active={buildObject.isLocated}>
             <BtnWrapper>
                 <StyledBtn onClick={cancleBuild}>취소</StyledBtn>
                 <StyledInput
@@ -99,11 +99,11 @@ const setBuildingModal = () => {
             </BtnWrapper>
         </ModalDiv>
     );
-};
+});
 
 export default setBuildingModal;
 
-const ModalDiv = styled.div`
+const ModalDiv = styled.div<ActiveModal>`
     position: absolute;
     z-index: 3;
 
@@ -114,7 +114,7 @@ const ModalDiv = styled.div`
     background: #c4c4c4;
     margin: -240px 0 0 -200px;
 
-    display: flex;
+    display: ${(props) => (props.active === true ? 'none' : 'flex')};
     flex-direction: column;
     justify-content: space-around;
     align-items: center;

--- a/frontend/src/pages/World/index.tsx
+++ b/frontend/src/pages/World/index.tsx
@@ -5,8 +5,6 @@ import { useQuery } from '@apollo/client';
 
 import styled from 'styled-components';
 import currentWorldState from '../../store/currentWorldState';
-import buildBuildingState from '../../store/buildBuildingState';
-import buildObjectState from '../../store/buildObjectState';
 import buildingUrls from '../../store/buildingUrlState';
 import objectUrls from '../../store/objectUrlState';
 
@@ -45,8 +43,6 @@ const World = (props: RouteComponentProps) => {
     const [currentWorld, setCurrentWorld] = useRecoilState(currentWorldState);
     const [buildingUrl, setBuildingUrl] = useRecoilState(buildingUrls);
     const [objectUrl, setObjectUrl] = useRecoilState(objectUrls);
-    const buildBuilding = useRecoilValue(buildBuildingState);
-    const buildObject = useRecoilValue(buildObjectState);
     const buildingInfo = useRecoilValue(buildingInfoState);
     const objectInfo = useRecoilValue(objectInfoState);
     const user = useRecoilValue(userState);
@@ -96,18 +92,16 @@ const World = (props: RouteComponentProps) => {
 
     return (
         <Inner>
-            {/* 아래 recoil 두 가지 상태에따라 맵이 다시 그려지니까 상태관련된 것은 하위컴포넌트 or 다른 곳으로 빼자 */}
             <Background
                 data={user.isInBuilding === NONE ? mapLayers : buildingLayer}
                 current={user.isInBuilding}
             />
-            {/* 빌딩이면 비디오 컴포넌트 추가 해야함 */}
             {buildingInfo.isBuilding ? <BuildingInfo /> : <></>}
             {objectInfo.isObject ? <ObjectInfo /> : <></>}
             <Modal />
             <NavigationBar props={props} />
-            {buildBuilding.isLocated ? <SetBuildingModal /> : <></>}
-            {buildObject.isLocated ? <SetObjectModal /> : <></>}
+            <SetBuildingModal />
+            <SetObjectModal />
         </Inner>
     );
 };


### PR DESCRIPTION
## PR 내용
* World 페이지에 있는 하위컴포넌트 관련 상태를 각각의 하위컴포넌트로 이동시켰습니다.
* 하위 컴포넌트 중 props 값이 World 페이지의 상태값들과 관련이 없는 경우 리렌더링이 계속되지 않도록 React.memo를 적용했습니다.