### PR TITLE
[Sprint 5] 에러 페이지 수정 및 세팅 페이지 캐시 정책 적용

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import React from 'react';
-import { BrowserRouter, Route, RouteComponentProps } from 'react-router-dom';
+import { BrowserRouter, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
 import { RecoilRoot } from 'recoil';
 
@@ -23,12 +23,14 @@ function App() {
         <ApolloProvider client={client}>
             <RecoilRoot>
                 <BrowserRouter>
-                    <Route exact path="/" component={Login} />
-                    <Route exact path="/login" component={Login} />
-                    <Route exact path="/setting" component={Setting} />
-                    <Route exact path="/selectworld" component={SelectWorld} />
-                    <Route exact path="/world" component={World} />
-                    <Route path="*" component={ErrorPage} />
+                    <Switch>
+                        <Route exact path="/" component={Login} />
+                        <Route exact path="/login" component={Login} />
+                        <Route exact path="/setting" component={Setting} />
+                        <Route exact path="/selectworld" component={SelectWorld} />
+                        <Route exact path="/world" component={World} />
+                        <Route path="*" component={ErrorPage} />
+                    </Switch>
                 </BrowserRouter>
             </RecoilRoot>
         </ApolloProvider>

--- a/frontend/src/pages/Setting/index.tsx
+++ b/frontend/src/pages/Setting/index.tsx
@@ -9,7 +9,9 @@ import Loading from '../Loading';
 import ErrorPage from '../Error';
 
 const Setting = (props: RouteComponentProps) => {
-    const { loading, error, data } = useQuery(getCharacterList);
+    const { loading, error, data } = useQuery(getCharacterList, {
+        fetchPolicy: 'cache-first',
+    });
 
     if (loading) return <Loading />;
     if (error) return <ErrorPage type={500} />;


### PR DESCRIPTION
# PR 내용
- 로그인 화면에 에러 페이지 나오는 부분 수정(라우팅 수정)
- 세팅 페이지에서의 아폴로 캐시 적용